### PR TITLE
chore: transfer ownership to @einride/team-cloud-control

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @filiptammergard @odsod
+* @einride/team-cloud-control


### PR DESCRIPTION
Part of system ownership of GitHub as a whole.
